### PR TITLE
Fix `fastglob` import

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs'
 import * as path from 'path'
 import type { Options as GlobOptions } from 'fast-glob'
-import * as fastglob from 'fast-glob'
+import fastglob from 'fast-glob'
 import micromatch from 'micromatch'
 import type { OutputBundle, Plugin, RenderedModule } from 'rollup'
 


### PR DESCRIPTION
When I try to build my project with this plugin installed I get the following error.
```
[vite-plugin-unused-code] fastglob.sync is not a function
error during build:
TypeError: fastglob.sync is not a function
    at Object.generateBundle (file:///project/node_modules/.pnpm/github.com+CyanSalt+vite-plugin-unused-code@c61342e99956b32b71672dcbe9b1aa657145abda_rollup@4_qwgspn4diys3coc5ovjilktgmi/node_modules/vite-plugin-unused-code/dist/index.mjs:102:40)
    at file:///project/node_modules/.pnpm/rollup@4.5.0/node_modules/rollup/dist/es/shared/node-entry.js:18598:40
```

This PR fixes the `fastglob` import so this doesn't occur.