### PR TITLE
fix: add Vite 8 / Rolldown compatibility

### DIFF
--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -1,7 +1,7 @@
 import * as path from 'path'
 import type { OutputBundle, RenderedModule } from 'rollup'
 
-function cleanupFilePath(id: string) {
+export function cleanupFilePath(id: string) {
   const searchIndex = id.indexOf('?')
   return searchIndex === -1 ? id : id.slice(0, searchIndex)
 }
@@ -13,11 +13,11 @@ function diff<T>(arr1: T[], arr2: T[]) {
   ]
 }
 
-interface ModuleInfo {
+export interface ModuleInfo {
   removedExports: RenderedModule['removedExports'],
 }
 
-export function getModules(bundle: OutputBundle) {
+export function getModules(bundle: OutputBundle, transformedModules?: Set<string>) {
   const modules = new Map<string, ModuleInfo>()
   for (const chunk of Object.values(bundle)) {
     const renderedModules = chunk.type === 'chunk' ? chunk.modules : {}
@@ -26,12 +26,19 @@ export function getModules(bundle: OutputBundle) {
       if (path.isAbsolute(file)) {
         const key = path.normalize(file)
         const existing = modules.get(key)
-        // Used by bundler
-        const removedExports = data.removedExports.filter(name => name !== '__esModule')
+        // Guard against missing removedExports (Rolldown doesn't provide it)
+        const removedExports = (data.removedExports ?? []).filter(name => name !== '__esModule')
         modules.set(key, {
           removedExports: existing ? diff(existing.removedExports, removedExports) : removedExports,
         })
       }
+    }
+  }
+  // Rolldown (used by Vite 8+) doesn't populate chunk.modules.
+  // Fall back to modules tracked via the transform hook.
+  if (modules.size === 0 && transformedModules) {
+    for (const key of transformedModules) {
+      modules.set(key, { removedExports: [] })
     }
   }
   return modules

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs'
 import * as path from 'path'
 import type { Plugin } from 'vite'
-import { getModules } from './bundler'
+import { cleanupFilePath, getModules } from './bundler'
 import { filterGlobs, searchGlobs } from './glob'
 
 function generateUnusedFilesMessage(unusedFiles: string[]) {
@@ -68,6 +68,7 @@ const unusedCodePlugin = (customOptions: Options): Plugin => {
     failOnHint: false,
     ...customOptions,
   }
+  const transformedModules = new Set<string>()
   return {
     enforce: 'post',
     apply: 'build',
@@ -77,6 +78,12 @@ const unusedCodePlugin = (customOptions: Options): Plugin => {
       options.log ??= config.logLevel === 'silent' ? 'none' : (
         config.logLevel === 'info' ? 'all' : 'unused'
       )
+    },
+    transform(_code, id) {
+      const file = cleanupFilePath(id)
+      if (path.isAbsolute(file)) {
+        transformedModules.add(path.normalize(file))
+      }
     },
     generateBundle(outputOptions, bundle) {
       const {
@@ -91,7 +98,7 @@ const unusedCodePlugin = (customOptions: Options): Plugin => {
       } = options
 
       const globs = patterns.concat(exclude.map(pattern => `!${pattern}`))
-      const modules = getModules(bundle)
+      const modules = getModules(bundle, transformedModules)
       let unusedFiles: string[] = []
       let unusedExports: ExportsGroup[] = []
 


### PR DESCRIPTION
## Problem

Vite 8 replaces Rollup with [Rolldown](https://rolldown.rs/), which breaks this plugin in two ways:

1. **`data.removedExports` is undefined** — Rolldown's `chunk.modules` entries don't have `removedExports`, causing a `TypeError: Cannot read properties of undefined (reading 'filter')`.

2. **`chunk.modules` is empty** — Rolldown doesn't populate `chunk.modules` for any chunks, so `getModules()` returns an empty map and every file is reported as unused.

## Fix

- Guard `removedExports` with nullish coalescing (`?? []`) to handle missing property
- Track all transformed modules via the `transform` hook, and fall back to that set when `chunk.modules` yields no results
- Both changes are backwards-compatible with Rollup / Vite ≤ 7