### PR TITLE
fix: always merge transformedModules into bundle modules

### DIFF
--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -34,11 +34,14 @@ export function getModules(bundle: OutputBundle, transformedModules?: Set<string
       }
     }
   }
-  // Rolldown (used by Vite 8+) doesn't populate chunk.modules.
-  // Fall back to modules tracked via the transform hook.
-  if (modules.size === 0 && transformedModules) {
+  // Rolldown (used by Vite 8+) may not fully populate chunk.modules,
+  // e.g. barrel re-exports can be missing. Merge in all modules tracked
+  // via the transform hook to ensure they are not reported as unused.
+  if (transformedModules) {
     for (const key of transformedModules) {
-      modules.set(key, { removedExports: [] })
+      if (!modules.has(key)) {
+        modules.set(key, { removedExports: [] })
+      }
     }
   }
   return modules


### PR DESCRIPTION
## Problem

With Vite 8+ (Rolldown), `chunk.modules` may be partially populated — files reached through barrel re-exports (index.ts re-export files) can be missing. The current fallback in `getModules` only uses `transformedModules` when `modules.size === 0`, which doesn't cover this case since the bundle does contain *some* modules.

This causes files that are actively imported and used (through barrel exports) to be incorrectly reported as unused.

## Fix

Always merge `transformedModules` into the bundle modules map, preserving any existing `removedExports` data from the bundle. This ensures any file that Vite transforms is recognized as used, regardless of whether Rolldown includes it in `chunk.modules`.

## Context

Follow-up to https://github.com/CyanSalt/vite-plugin-unused-code/commit/571a7ede30432a4e7b8ae9a1b4e2ff893ba7a04c which added the `transformedModules` tracking but only used it as a fallback.